### PR TITLE
Add Golang style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Please read the [contributing guidelines](https://github.com/jcoady9/awesome-bes
 
 # Go
 * [Twelve Go Best Practices](https://talks.golang.org/2013/bestpractices.slide#1)
+* [Official Go Style Guide](https://github.com/golang/go/wiki/CodeReviewComments)
 
 # Javascript
 * [Google Javascript Style Guide](https://google.github.io/styleguide/javascriptguide.xml)


### PR DESCRIPTION
Adds the style guide on the official Go repository on GitHub.  
Issues Referenced:  #1.
