### PR TITLE
Add Github's Ruby Style Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Please read the [contributing guidelines](https://github.com/jcoady9/awesome-bes
 
 # Ruby
 * [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide)
+* [Github's Ruby Style Guide](https://github.com/styleguide/ruby)
 
 # Rust
 * [Rust Guidelines](http://aturon.github.io/)


### PR DESCRIPTION
Adds a link to Github's Ruby Style Guide in README.md.
